### PR TITLE
Dockerfileからcomposerインストーラの検証を除外

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ RUN easy_install blockdiag && \
 
 # install composer↲
 RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && \
-    php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
     php composer-setup.php --install-dir=/usr/bin && \
     php -r "unlink('composer-setup.php');"
 


### PR DESCRIPTION
composerがバージョンアップされるたびに検証がエラーになるため除外